### PR TITLE
feat: Add "Save QR Code" functionality

### DIFF
--- a/app/src/main/java/com/app/open/piccollab/presentation/common/Components.kt
+++ b/app/src/main/java/com/app/open/piccollab/presentation/common/Components.kt
@@ -1,5 +1,7 @@
 package com.app.open.piccollab.presentation.common
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -52,7 +54,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import coil3.Bitmap
+import androidx.core.graphics.createBitmap
 import com.app.open.piccollab.R
 import com.app.open.piccollab.core.db.room.entities.EventFolder
 import com.app.open.piccollab.core.models.event.NewEventItem
@@ -364,10 +366,14 @@ fun ShareEventQrCard(
     bitmapQR: Bitmap,
     eventFolder: EventFolder?,
     onDismiss: () -> Unit,
-    onClickSave: () -> Unit = {},
+    onClickSave: (bitmap: Bitmap, eventFolder: EventFolder?) -> Unit = { bitmapQR, evenFolder -> },
     onClickShare: () -> Unit = {}
 ) {
     val localView = LocalView.current
+    val viewBitmap = createBitmap(localView.width, localView.height)
+    val canvas = Canvas(viewBitmap)
+    canvas.drawColor(android.graphics.Color.WHITE)
+    localView.draw(canvas)
     Dialog(onDismissRequest = onDismiss) {
         Card {
             Box(modifier = Modifier.padding(24.dp)) {
@@ -390,7 +396,9 @@ fun ShareEventQrCard(
                     }
                     SpacerHeight(12.dp)
                     Column(modifier = Modifier.fillMaxWidth()) {
-                        ButtonWithText("Save", modifier = Modifier.fillMaxWidth()) { onClickSave }
+                        ButtonWithText("Save", modifier = Modifier.fillMaxWidth()) {
+                            onClickSave(viewBitmap, eventFolder)
+                        }
                         ButtonWithText("Share", modifier = Modifier.fillMaxWidth()) { onClickShare }
                     }
                 }

--- a/app/src/main/java/com/app/open/piccollab/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/app/open/piccollab/presentation/ui/home/HomeScreen.kt
@@ -67,7 +67,10 @@ fun HomeScreen(
                     gson.toJson(shareEventFolder),
                     screenWidth
                 ), shareEventFolder,
-                onDismiss = { shareEventFolder = null }
+                onDismiss = { shareEventFolder = null },
+                onClickSave = { bitmap, eventItem ->
+                    viewmodel.saveEventQrCode(context, bitmap, eventItem)
+                }
             ) {
                 shareEventFolder = null
             }

--- a/app/src/main/java/com/app/open/piccollab/presentation/ui/home/HomeViewmodel.kt
+++ b/app/src/main/java/com/app/open/piccollab/presentation/ui/home/HomeViewmodel.kt
@@ -1,11 +1,14 @@
 package com.app.open.piccollab.presentation.ui.home
 
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import coil3.Bitmap
 import com.app.open.piccollab.core.db.room.entities.EventFolder
 import com.app.open.piccollab.core.db.room.repositories.EventFolderRepository
 import com.app.open.piccollab.core.models.event.NewEventItem
+import com.app.open.piccollab.core.utils.FileUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -67,5 +70,13 @@ class HomeViewmodel @Inject constructor(
             _loadingState.emit(LoadingState.Idle)
         }
         eventFolderRepository.refreshEventFolderWithDrive(viewModelScope)
+    }
+
+    fun saveEventQrCode(context: Context, bitmap: Bitmap, eventItem: EventFolder?) {
+        viewModelScope.launch {
+            eventItem?.let {
+                FileUtil.savePhotoToStorage(context, it, bitmap)
+            }
+        }
     }
 }

--- a/core/src/main/java/com/app/open/piccollab/core/utils/FileUtil.kt
+++ b/core/src/main/java/com/app/open/piccollab/core/utils/FileUtil.kt
@@ -1,10 +1,16 @@
 package com.app.open.piccollab.core.utils
 
+import android.content.ContentValues
 import android.content.Context
+import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Environment
+import android.provider.MediaStore
 import android.util.Log
 import android.webkit.MimeTypeMap
+import com.app.open.piccollab.core.db.room.entities.EventFolder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 import java.text.SimpleDateFormat
@@ -56,7 +62,7 @@ object FileUtil {
         return fileName
     }
 
-    fun getFileFromUri(context: Context,uri: Uri): File {
+    fun getFileFromUri(context: Context, uri: Uri): File {
         val file = createTempFile()
         context.contentResolver.openInputStream(uri).use { inputStream ->
             file.outputStream().use { outputStream ->
@@ -65,5 +71,46 @@ object FileUtil {
         }
         Log.d(TAG, "ProfileScreen: file $file")
         return file.toFile()
+    }
+
+    suspend fun savePhotoToStorage(
+        context: Context,
+        eventFolder: EventFolder,
+        bitmap: Bitmap
+    ) {
+        withContext(Dispatchers.IO) {
+            val filesDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+            val appDirectory = File(filesDir, "PicCollab")
+            if (!appDirectory.exists()) {
+                Log.d(TAG, "savePhotoToStorage: creating directory")
+                appDirectory.mkdir()
+            }
+
+            val resolver = context.contentResolver
+
+            val collection = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+
+            val contentValue = ContentValues().apply {
+                put(
+                    MediaStore.Images.Media.DISPLAY_NAME,
+                    "${eventFolder.folderName}_${eventFolder.folderId}.png"
+                )
+                put(MediaStore.Images.Media.IS_PENDING, 1)
+            }
+
+            val contentUri = resolver.insert(collection, contentValue)
+
+            contentUri?.let {
+                resolver.openOutputStream(it).use { fos ->
+                    fos?.let {
+                        bitmap.compress(Bitmap.CompressFormat.PNG, 80, fos)
+                    }
+                }
+                contentValue.clear()
+                contentValue.put(MediaStore.Images.Media.IS_PENDING, 0)
+                resolver.update(contentUri, contentValue, null, null)
+            }
+        }
+
     }
 }


### PR DESCRIPTION
This commit introduces the ability for users to save the QR code for an event to their device's photo gallery.

**Key Changes:**

- A `savePhotoToStorage` function has been added to `FileUtil` to handle saving a `Bitmap` to the device's external pictures directory.
- `HomeViewmodel` now includes a `saveEventQrCode` function that calls `FileUtil.savePhotoToStorage`.
- The `QrDialog` composable now captures a `Bitmap` of the dialog view itself.
- The "Save" button in the `QrDialog` now triggers the `onClickSave` callback, passing the captured `Bitmap` and event data.
- In `HomeScreen`, the `onClickSave` callback is implemented to call the new `viewmodel.saveEventQrCode` function, completing the save operation.